### PR TITLE
Fixed typo in vstcomponentbase.cpp - ComponentBase::disconnect()

### DIFF
--- a/source/vst/vstcomponentbase.cpp
+++ b/source/vst/vstcomponentbase.cpp
@@ -108,7 +108,7 @@ tresult PLUGIN_API ComponentBase::disconnect (IConnectionPoint* other)
 {
 	if (peerConnection && other == peerConnection)
 	{
-		peerConnection->release (),
+		peerConnection->release ();
 		peerConnection = 0;
 		return kResultOk;
 	}


### PR DESCRIPTION
obvious fix to remove warning