### PR TITLE
Fixed units and programLists not being cleared on terminate(), improved performance of MidiMapping validator

### DIFF
--- a/source/vst/vsteditcontroller.cpp
+++ b/source/vst/vsteditcontroller.cpp
@@ -417,6 +417,15 @@ tresult EditControllerEx1::notifyProgramListChange (ProgramListID listId, int32 
 	return result;
 }
 
+//-----------------------------------------------------------------------------
+tresult EditControllerEx1::terminate()
+{
+    units.clear ();
+    programLists.clear ();
+
+    return EditController::terminate ();
+}
+
 //------------------------------------------------------------------------
 int32 PLUGIN_API EditControllerEx1::getProgramListCount ()
 {

--- a/source/vst/vsteditcontroller.cpp
+++ b/source/vst/vsteditcontroller.cpp
@@ -422,6 +422,7 @@ tresult EditControllerEx1::terminate()
 {
     units.clear ();
     programLists.clear ();
+    programIndexMap.clear ();
 
     return EditController::terminate ();
 }

--- a/source/vst/vsteditcontroller.h
+++ b/source/vst/vsteditcontroller.h
@@ -307,7 +307,7 @@ public:
 	tresult notifyProgramListChange (ProgramListID listId, int32 programIndex = kAllProgramInvalid);
 
     //---from EditController---------
-    tresult PLUGIN_API terminate  () SMTG_OVERRIDE;
+    tresult PLUGIN_API terminate () SMTG_OVERRIDE;
 
     //---from IUnitInfo------------------
 	int32 PLUGIN_API getUnitCount () SMTG_OVERRIDE { return static_cast<int32> (units.size ()); }

--- a/source/vst/vsteditcontroller.h
+++ b/source/vst/vsteditcontroller.h
@@ -306,7 +306,10 @@ public:
 	/** Notifies the host about program list changes. */
 	tresult notifyProgramListChange (ProgramListID listId, int32 programIndex = kAllProgramInvalid);
 
-	//---from IUnitInfo------------------
+    //---from EditController---------
+    tresult PLUGIN_API terminate  () SMTG_OVERRIDE;
+
+    //---from IUnitInfo------------------
 	int32 PLUGIN_API getUnitCount () SMTG_OVERRIDE { return static_cast<int32> (units.size ()); }
 	tresult PLUGIN_API getUnitInfo (int32 unitIndex, UnitInfo& info /*out*/) SMTG_OVERRIDE;
 


### PR DESCRIPTION
Ensure to clear up **units** and **programLists** when calling **terminate()** on an **EditControllerEx1**. **EditController** clears up **params** upon calling **terminate()**, so I would expect **EditControllerEx1** to also clear up its members.

Greatly improve performance of the MidiMapping validator for plugins with high parameter counts, through caching parameter ids in a set before looping over the Midi parameters.


