### PR TITLE
Add missing includes for gcc >= 10

### DIFF
--- a/samples/vst/mda-vst3/source/mdaPianoProcessor.cpp
+++ b/samples/vst/mda-vst3/source/mdaPianoProcessor.cpp
@@ -19,6 +19,7 @@
 #include "mdaPianoData.h"
 
 #include <math.h>
+#include <stdio.h>
 
 namespace Steinberg {
 namespace Vst {
@@ -224,7 +225,7 @@ void PianoProcessor::doProcessing (ProcessData& data)
 
 				if (!(l > -2.0f) || !(l < 2.0f))
 				{
-					printf ("what is this shit?   %d,  %f,  %f\n", i, x, V->f0);
+					printf ("what is this?   %d,  %f,  %f\n", i, x, V->f0);
 					l = 0.0f;
 				}  
 				if (!(r > -2.0f) || !(r < 2.0f))

--- a/source/common/threadchecker_linux.cpp
+++ b/source/common/threadchecker_linux.cpp
@@ -38,7 +38,9 @@
 
 #if SMTG_OS_LINUX
 
+#include <cstdio>
 #include <pthread.h>
+#include <stdio.h>
 
 //------------------------------------------------------------------------
 namespace Steinberg {


### PR DESCRIPTION
When compiling with gcc >= 10.2.0 the build fails on missing includes.
This adds the missing includes and fixes #20

source/common/threadchecker_linux.cpp:
Add missing includes `<cstdio>` and `<stdio.h>` for `stderr` and
`fprintf` (respectively)

samples/vst/mda-vst3/source/mdaPianoProcessor.cpp:
Add missing include of `<stdio.h>` for an `printf()` call.
Make the `printf()` call less offensive.