### PR TITLE
Fix incorrect string copy regression in HostAttributeList::getString

### DIFF
--- a/source/vst/hosting/hostclasses.cpp
+++ b/source/vst/hosting/hostclasses.cpp
@@ -298,7 +298,7 @@ tresult PLUGIN_API HostAttributeList::getString (AttrID aid, TChar* string, uint
 	{
 		uint32 stringSize = 0;
 		const TChar* _string = it->second->stringValue (stringSize);
-		memcpy (string, _string, std::min<uint32> (stringSize, sizeInBytes));
+		memcpy (string, _string, std::min<uint32> (stringSize * sizeof( TChar ), sizeInBytes));
 		return kResultTrue;
 	}
 	return kResultFalse;


### PR DESCRIPTION
In HostAttributeList::getString stringSize should be multiplied by sizeof TChar because it is copying bytes not characters.
This was causing many plugins to display garbage in channel names when they query for attributes in response to Vst::ChannelContext::IInfoListener