### PR TITLE
Restore MinGW build

### DIFF
--- a/samples/vst-hosting/editorhost/CMakeLists.txt
+++ b/samples/vst-hosting/editorhost/CMakeLists.txt
@@ -74,8 +74,7 @@ if(SMTG_ADD_VST3_HOSTING_SAMPLES)
         endif(MSVC)
         if(MINGW)
             # It causes the UNICODE preprocessor macro to be predefined, and chooses Unicode-capable runtime startup code.
-            set_target_properties(${target}
-                PROPERTIES
+            set(APP_PROPERTIES
                     LINK_FLAGS -municode
             )
         endif(MINGW)

--- a/source/vst/moduleinfo/json.h
+++ b/source/vst/moduleinfo/json.h
@@ -49,7 +49,7 @@
 #include <stddef.h>
 #include <string.h>
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #define json_weak __inline
 #elif defined(__clang__) || defined(__GNUC__)
 #define json_weak __attribute__((weak))


### PR DESCRIPTION
These changes will allow building the SDK using the MinGW compiler from msys2.org