### PR TITLE
AUv3Wrapper: fix crash building parameter groups

### DIFF
--- a/source/vst/auv3wrapper/Shared/AUv3Wrapper.mm
+++ b/source/vst/auv3wrapper/Shared/AUv3Wrapper.mm
@@ -1504,7 +1504,7 @@ using namespace Vst;
 			{
 				const auto& str = parameterGroups.at (i);
 				if (str == fullParamName)
-					break;
+					return i;
 
 				++groupIdx;
 			}


### PR DESCRIPTION
Fixes a crash when wrapping a plugin that uses parameter groups / UnitInfo.

The value returned by `-buildParameterGroup:` is used to index into the `paramArrayWithHierarchy` array.

The size of `paramArrayWithHierarchy` is `unitInfos.size() + 1`, however `buildParameterGroup:` was adding an entry to `parameterGroups` for each parameter, rather than group, and therefore returning invalid indexes for `paramArrayWithHierarchy`.

This fix ensures `parameterGroups` contains a single entry for each unit info.