### PR TITLE
AUv3Wrapper: fix crash for empty parameter groups

### DIFF
--- a/source/vst/auv3wrapper/Shared/AUv3Wrapper.mm
+++ b/source/vst/auv3wrapper/Shared/AUv3Wrapper.mm
@@ -1445,21 +1445,8 @@ using namespace Vst;
 			[self setControllerParameter:pi.id value:pi.defaultNormalizedValue];
 
 			// add parameter to the paramArrayWithHierarchy (with hierarchy/AUParameterGroups)
-			// initialize paramArrayWithHierarchy once (if i == 0)
-			if (i == 0)
-			{
-				bool rootInitialized = false;
-				for (auto it = unitInfos.begin (); it != unitInfos.end (); ++it)
-				{
-					[paramArrayWithHierarchy addObject:[[NSMutableArray alloc] init]];
-
-					if (it->second.parentUnitId == -1)
-						rootInitialized = true;
-				}
-
-				if (!rootInitialized)
-					[paramArrayWithHierarchy addObject:[[NSMutableArray alloc] init]];
-			}
+			while ([paramArrayWithHierarchy count] <= groupIdx)
+ 				[paramArrayWithHierarchy addObject:[[NSMutableArray alloc] init]];
 
 			NSUInteger groupOfParam = (NSUInteger)groupIdx;
 			[[paramArrayWithHierarchy objectAtIndex:groupOfParam] addObject:sPar];


### PR DESCRIPTION
Fixes a crash when wrapping plugins that have one or more unitinfos with no public parameters.

Because `-buildParameterGroup:` is called for each parameter, `parameterGroups` never contains unitInfos that have no public parameters. `paramArrayWithHierarchy` however will contain an entry for each unitInfo, even if it has no (public) parameters.

This inconsistency causes a crash on line 1345 where `parameterGroups` is expected to contain `paramArrayWithHierarchy.length - 1` elements: https://github.com/steinbergmedia/vst3_public_sdk/blob/55d7ed3c6a25496b41fc4440aaad4fae1b967d37/source/vst/auv3wrapper/Shared/AUv3Wrapper.mm#L1345

This PR changes to logic to ensure that `paramArrayWithHierarchy` contains the number of elements as expected by the size of `parameterGroups`.