### PR TITLE
AUv3Wrapper: remove duplicate -loadAudioFile: method declaration

### DIFF
--- a/source/vst/auv3wrapper/Shared/AUv3AudioEngine.h
+++ b/source/vst/auv3wrapper/Shared/AUv3AudioEngine.h
@@ -42,7 +42,6 @@
 
 @property (assign) AUAudioUnit* currentAudioUnit;
 
-- (NSError*)loadAudioFile:(NSURL*)url;
 - (instancetype)initWithComponentType:(uint32_t)unitComponentType;
 - (void)loadAudioUnitWithComponentDescription:(AudioComponentDescription)desc
                                    completion:(void (^) (void))completionBlock;


### PR DESCRIPTION
Fixes the following warning:

```
AUv3AudioEngine.h:51:1: warning: multiple declarations of method 'loadAudioFile:' found and ignored [-Wduplicate-method-match]
- (NSError*)loadAudioFile:(NSURL*)url;
^
AUv3AudioEngine.h:45:1: note: previous declaration is here
- (NSError*)loadAudioFile:(NSURL*)url;
^
```