### PR TITLE
Fix Linux build issue

### DIFF
--- a/source/vst/moduleinfo/moduleinfoparser.h
+++ b/source/vst/moduleinfo/moduleinfoparser.h
@@ -41,6 +41,7 @@
 #include <iostream>
 #include <optional>
 #include <string_view>
+#include <limits>
 
 //------------------------------------------------------------------------
 namespace Steinberg::ModuleInfoLib {


### PR DESCRIPTION
I got this when trying to build on Linux:
_vst3sdk/public.sdk/source/vst/moduleinfo/moduleinfoparser.cpp:110:73: error: ‘numeric_limits’ is not a member of ‘std’_

This change fixes that.