### PR TITLE
Include limits to avoid compilation error on module info parser.

### DIFF
--- a/source/vst/moduleinfo/moduleinfoparser.cpp
+++ b/source/vst/moduleinfo/moduleinfoparser.cpp
@@ -39,7 +39,7 @@
 #include "jsoncxx.h"
 #include "pluginterfaces/base/ipluginbase.h"
 #include <stdexcept>
-
+#include <limits>
 //------------------------------------------------------------------------
 namespace Steinberg::ModuleInfoLib {
 namespace {


### PR DESCRIPTION
Just a simple include directive.