### PR TITLE
vsteditcontroller, vstparameters: add bounds checks

### DIFF
--- a/source/vst/vsteditcontroller.cpp
+++ b/source/vst/vsteditcontroller.cpp
@@ -349,6 +349,9 @@ bool EditControllerEx1::addUnit (Unit* unit)
 //------------------------------------------------------------------------
 tresult PLUGIN_API EditControllerEx1::getUnitInfo (int32 unitIndex, UnitInfo& info /*out*/)
 {
+	if (unitIndex < 0 || unitIndex >= static_cast<int32>(units.size()))
+		return kResultFalse;
+
 	if (Unit* unit = units.at (unitIndex))
 	{
 		info = unit->getInfo ();

--- a/source/vst/vstparameters.cpp
+++ b/source/vst/vstparameters.cpp
@@ -390,6 +390,15 @@ Parameter* ParameterContainer::addParameter (const ParameterInfo& info)
 }
 
 //------------------------------------------------------------------------
+Parameter* ParameterContainer::getParameterByIndex (int32 index) const
+{
+	if (!params || index < 0 || index >= static_cast<int32>(params->size()))
+		return nullptr;
+
+	return params->at (index);
+}
+
+//------------------------------------------------------------------------
 Parameter* ParameterContainer::getParameter (ParamID tag) const
 {
 	if (params)

--- a/source/vst/vstparameters.h
+++ b/source/vst/vstparameters.h
@@ -212,7 +212,7 @@ public:
 	int32 getParameterCount () const { return params ? static_cast<int32> (params->size ()) : 0; }
 
 	/** Gets parameter by index. */
-	Parameter* getParameterByIndex (int32 index) const { return params ? params->at (index) : nullptr; }
+	Parameter* getParameterByIndex (int32 index) const;
 
 	/** Removes all parameters. */
 	void removeAll ()


### PR DESCRIPTION
Add bounds checks around calls to std::vector::at(). This is consistent with how bounds checking is handled in other places in the sdk source code.