### PR TITLE
Compatibility improvements

### DIFF
--- a/samples/vst-utilities/moduleinfotool/source/main.cpp
+++ b/samples/vst-utilities/moduleinfotool/source/main.cpp
@@ -35,11 +35,13 @@
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 //-----------------------------------------------------------------------------
 
+#include "public.sdk/source/common/memorystream.h"
 #include "public.sdk/source/vst/hosting/module.h"
 #include "public.sdk/source/vst/moduleinfo/moduleinfocreator.h"
 #include "public.sdk/source/vst/moduleinfo/moduleinfoparser.h"
 #include "base/source/fcommandline.h"
 #include "pluginterfaces/vst/vsttypes.h"
+#include "pluginterfaces/base/iplugincompatibility.h"
 #include <cstdio>
 #include <fstream>
 #include <iostream>
@@ -110,6 +112,35 @@ std::optional<ModuleInfo::CompatibilityList> openAndParseCompatJSON (const std::
 }
 
 //------------------------------------------------------------------------
+std::optional<ModuleInfo::CompatibilityList> loadCompatibilityFromModule (const VST3::Hosting::Module& module)
+{
+	const auto& factory = module.getFactory();
+	const auto& infos = factory.classInfos();
+
+	const auto iter = std::find_if (infos.begin(), infos.end(), [&] (const auto& info)
+	{
+		return info.category() == kPluginCompatibilityClass;
+	});
+
+	if (iter == infos.end())
+		return {};
+
+	const auto compatibility = factory.createInstance<Steinberg::IPluginCompatibility> (iter->ID());
+
+	if (compatibility == nullptr)
+		return {};
+
+	Steinberg::MemoryStream stream;
+
+	if (compatibility->getCompatibilityJSON (&stream) != kResultOk)
+		return {};
+
+	const std::string_view streamView (stream.getData(), stream.getSize());
+
+	return ModuleInfoLib::parseCompatibilityJson (streamView, nullptr);
+}
+
+//------------------------------------------------------------------------
 int createJSON (const std::optional<ModuleInfo::CompatibilityList>& compat,
                 const std::string& modulePath, const std::string& moduleVersion,
                 std::ostream& outStream)
@@ -124,6 +155,9 @@ int createJSON (const std::optional<ModuleInfo::CompatibilityList>& compat,
 	auto moduleInfo = ModuleInfoLib::createModuleInfo (*module, false);
 	if (compat)
 		moduleInfo.compatibility = *compat;
+	else if (auto loaded = loadCompatibilityFromModule (*module))
+		moduleInfo.compatibility = *loaded;
+
 	moduleInfo.version = moduleVersion;
 
 	std::stringstream output;

--- a/source/vst/hosting/module.cpp
+++ b/source/vst/hosting/module.cpp
@@ -270,7 +270,7 @@ void ClassInfo::parseSubCategories (const std::string& str) noexcept
 	std::stringstream stream (str);
 	std::string item;
 	while (std::getline (stream, item, '|'))
-		data.subCategories.emplace_back (move (item));
+		data.subCategories.emplace_back (std::move (item));
 }
 
 //------------------------------------------------------------------------

--- a/source/vst/hosting/module_linux.cpp
+++ b/source/vst/hosting/module_linux.cpp
@@ -43,7 +43,7 @@
 #include <sys/utsname.h>
 #include <unistd.h>
 
-#if (__cplusplus >= 201707L)
+#if (__cplusplus >= 201703L)
 #if __has_include(<filesystem>)
 #define USE_EXPERIMENTAL_FS 0
 #elif __has_include(<experimental/filesystem>)

--- a/source/vst/moduleinfo/moduleinfo.h
+++ b/source/vst/moduleinfo/moduleinfo.h
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/source/vst/moduleinfo/moduleinfoparser.cpp
+++ b/source/vst/moduleinfo/moduleinfoparser.cpp
@@ -141,7 +141,7 @@ struct ModuleInfoJsonParser
 		uint32_t parsed {0};
 		if (auto obj = value.asObject ())
 		{
-			for (const auto& el : *obj)
+			for (const auto el : *obj)
 			{
 				auto elementName = el.name ().text ();
 				if (elementName == "Vendor")
@@ -172,7 +172,7 @@ struct ModuleInfoJsonParser
 					auto flags = el.value ().asObject ();
 					if (!flags)
 						throw parse_error ("Expect 'Flags' to be a JSON Object", el.name ());
-					for (const auto& flag : *flags)
+					for (const auto flag : *flags)
 					{
 						auto flagName = flag.name ().text ();
 						auto flagValue = flag.value ().asBoolean ();
@@ -229,7 +229,7 @@ struct ModuleInfoJsonParser
 		auto array = value.asArray ();
 		if (!array)
 			throw parse_error ("Expect Classes Array", value);
-		for (const auto& classInfoEl : *array)
+		for (const auto classInfoEl : *array)
 		{
 			auto classInfo = classInfoEl.value ().asObject ();
 			if (!classInfo)
@@ -239,7 +239,7 @@ struct ModuleInfoJsonParser
 
 			uint32_t parsed {0};
 
-			for (const auto& el : *classInfo)
+			for (const auto el : *classInfo)
 			{
 				auto elementName = el.name ().text ();
 				if (elementName == "CID")
@@ -291,7 +291,7 @@ struct ModuleInfoJsonParser
 					auto subCatArr = el.value ().asArray ();
 					if (!subCatArr)
 						throw parse_error ("Expect Array here", el.value ());
-					for (const auto& catEl : *subCatArr)
+					for (const auto catEl : *subCatArr)
 					{
 						auto cat = getText (catEl.value ());
 						ci.subCategories.emplace_back (cat);
@@ -319,13 +319,13 @@ struct ModuleInfoJsonParser
 					auto snapArr = el.value ().asArray ();
 					if (!snapArr)
 						throw parse_error ("Expect Array here", el.value ());
-					for (const auto& snapEl : *snapArr)
+					for (const auto snapEl : *snapArr)
 					{
 						auto snap = snapEl.value ().asObject ();
 						if (!snap)
 							throw parse_error ("Expect Object here", snapEl.value ());
 						ModuleInfo::Snapshot snapshot;
-						for (const auto& spEl : *snap)
+						for (const auto spEl : *snap)
 						{
 							auto spElName = spEl.name ().text ();
 							if (spElName == "Path")
@@ -369,14 +369,14 @@ struct ModuleInfoJsonParser
 		auto arr = value.asArray ();
 		if (!arr)
 			throw parse_error ("Expect Array here", value);
-		for (const auto& el : *arr)
+		for (const auto el : *arr)
 		{
 			auto obj = el.value ().asObject ();
 			if (!obj)
 				throw parse_error ("Expect Object here", el.value ());
 
 			ModuleInfo::Compatibility compat;
-			for (const auto& objEl : *obj)
+			for (const auto objEl : *obj)
 			{
 				auto elementName = objEl.name ().text ();
 				if (elementName == "New")
@@ -386,7 +386,7 @@ struct ModuleInfoJsonParser
 					auto oldElArr = objEl.value ().asArray ();
 					if (!oldElArr)
 						throw parse_error ("Expect Array here", objEl.value ());
-					for (const auto& old : *oldElArr)
+					for (const auto old : *oldElArr)
 					{
 						compat.oldCID.emplace_back (getText (old.value ()));
 					}
@@ -416,7 +416,7 @@ struct ModuleInfoJsonParser
 		};
 
 		uint32_t parsed {0};
-		for (const auto& el : *docObj)
+		for (const auto el : *docObj)
 		{
 			auto elementName = el.name ().text ();
 			if (elementName == "Name")

--- a/source/vst/moduleinfo/moduleinfoparser.cpp
+++ b/source/vst/moduleinfo/moduleinfoparser.cpp
@@ -39,6 +39,7 @@
 #include "jsoncxx.h"
 #include "pluginterfaces/base/ipluginbase.h"
 #include <stdexcept>
+#include <limits>
 
 //------------------------------------------------------------------------
 namespace Steinberg::ModuleInfoLib {


### PR DESCRIPTION
These are changes that we made to facilitate use of the VST3 SDK in JUCE.

The most notable update is that the moduleinfotool is able to include compatibility information provided by the IPluginCompatibility object. This means that the plugin can act as the single-source-of-truth for compatibility information. Information in the moduleinfo.json is guaranteed to be in-sync with the IPluginCompatibility object.

The other changes just add missing includes, and fix compiler warnings.