### PR TITLE
Avoid outputting build artifacts to /VST3Inspector

### DIFF
--- a/samples/vst-hosting/inspectorapp/CMakeLists.txt
+++ b/samples/vst-hosting/inspectorapp/CMakeLists.txt
@@ -52,7 +52,7 @@ if(TARGET vstgui AND TARGET vstgui_standalone)
     if(NOT SMTG_MAC)
         set_target_properties(${target}
             PROPERTIES
-                RUNTIME_OUTPUT_DIRECTORY $<$<CONFIG:Debug>:${CMAKE_BINARY_DIR}/bin/Debug/>$<$<CONFIG:Release>:${CMAKE_BINARY_DIR}/bin/Release/>$<$<CONFIG:ReleaseLTO>:${CMAKE_BINARY_DIR}/bin/ReleaseLTO/>/VST3Inspector
+                RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/$<$<CONFIG:Debug>:bin/Debug>$<$<CONFIG:Release>:bin/Release>$<$<CONFIG:ReleaseLTO>:bin/ReleaseLTO>/VST3Inspector
         )
     endif(NOT SMTG_MAC)
 


### PR DESCRIPTION
When the build type isn't Debug, Release or ReleaseLTO, the build artifacts got put into /VST3Inspector and it will fail without root permission.

```
[ 99%] Linking CXX executable /VST3Inspector/VST3Inspector
Error creating directory "/VST3Inspector/Resources".
make[2]: *** [public.sdk/samples/vst-hosting/inspectorapp/CMakeFiles/VST3Inspector.dir/build.make:220: /VST3Inspector/VST3Inspector] Error 1
make[1]: *** [CMakeFiles/Makefile2:1084: public.sdk/samples/vst-hosting/inspectorapp/CMakeFiles/VST3Inspector.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```