### PR TITLE
Fix "Missing field initializer" warning in vstparameters.h

### DIFF
--- a/source/vst/vstparameters.h
+++ b/source/vst/vstparameters.h
@@ -98,7 +98,7 @@ public:
 	OBJ_METHODS (Parameter, FObject)
 //------------------------------------------------------------------------
 protected:
-	ParameterInfo info {0};
+	ParameterInfo info {};
 	ParamValue valueNormalized {0.};
 	int32 precision {4};
 };


### PR DESCRIPTION
Fixes a warning reported by Clang with `-Wmissing-field-initializers` enabled.

Coming from a commonly included header, this warning is particularly noisy.