### PR TITLE
Make LegacyMIDICCOutEvent arguments const for pitch bend value helpers.

### DIFF
--- a/source/vst/vsteventshelper.h
+++ b/source/vst/vsteventshelper.h
@@ -83,7 +83,7 @@ inline int8 getMIDICCOutValue (ParamValue value)
 
 //------------------------------------------------------------------------
 /** Returns pitchbend value from a PitchBend LegacyMIDICCOut Event */
-inline int16 getPitchBendValue (LegacyMIDICCOutEvent& e)
+inline int16 getPitchBendValue (const LegacyMIDICCOutEvent& e)
 {
 	return ((e.value & 0x7F)| ((e.value2 & 0x7F) << 7));
 }
@@ -99,7 +99,7 @@ inline void setPitchBendValue (LegacyMIDICCOutEvent& e, ParamValue value)
 
 //------------------------------------------------------------------------
 /** Returns normalized pitchbend value from a PitchBend LegacyMIDICCOut Event */
-inline float getNormPitchBendValue (LegacyMIDICCOutEvent& e)
+inline float getNormPitchBendValue (const LegacyMIDICCOutEvent& e)
 {
 	float val = (float)getPitchBendValue (e) / (float)0x3FFF;
 	if (val < 0)


### PR DESCRIPTION
For the getter helpers getPitchBendValue() and getNormPitchBendValue(), the event is not modified by the function.