### PR TITLE
Fix mismatching noteIds in AUWrapper

### DIFF
--- a/source/vst/auwrapper/auwrapper.mm
+++ b/source/vst/auwrapper/auwrapper.mm
@@ -1909,7 +1909,9 @@ ComponentResult AUWrapper::StartNote (MusicDeviceInstrumentID inInstrument,
                                       NoteInstanceID* outNoteInstanceID, UInt32 inOffsetSampleFrame,
                                       const MusicDeviceNoteParams& inParams)
 {
-	NoteInstanceID noteID = ((UInt8)inParams.mPitch) | ((noteCounter++) << 8);
+	NoteInstanceID noteID = (UInt8)inParams.mPitch;
+	if (outNoteInstanceID)
+		noteID |= ((noteCounter++) << 8);
 
 	Event e = {};
 


### PR DESCRIPTION
This PR fixes a problem where `noteOff` events from `AUWrapper` would have different noteIds than the `noteOn`.

The problem is that `outNoteInstanceID` is `NULL` when called from `MusicDeviceBase::HandleNoteOn` in response to MIDI events, and the note number is passed as the `inNoteInstanceID` to `AUWrapper::StopNote` in response to MIDI note off message:
```c++
OSStatus	MusicDeviceBase::HandleNoteOn(	UInt8 	inChannel,
                                                UInt8 	inNoteNumber,
                                                UInt8 	inVelocity,
                                                UInt32 	inStartFrame)
{
	MusicDeviceNoteParams params;
	params.argCount = 2;
	params.mPitch = inNoteNumber;
	params.mVelocity = inVelocity;
	return StartNote (kMusicNoteEvent_UseGroupInstrument, inChannel, NULL, inStartFrame, params);
}

OSStatus	MusicDeviceBase::HandleNoteOff(	UInt8 	inChannel,
											UInt8 	inNoteNumber,
											UInt8 	inVelocity,
											UInt32 	inStartFrame)
{
	return StopNote (inChannel, inNoteNumber, inStartFrame);
}
```

Therefore, to ensure the noteOff noteId matches the noteOn, this patch uses only the pitch (i.e. note number) as the noteId if `outNoteInstanceID` is NULL.