### PR TITLE
I discovered cwe-416 vulnerability in your source code

### DIFF
--- a/source/vst/hosting/module_linux.cpp
+++ b/source/vst/hosting/module_linux.cpp
@@ -164,8 +164,10 @@ public:
 		if (!filesystem::is_directory (modulePath))
 			return {};
 
-		stem.replace_extension (".so");
-		modulePath /= stem;
+		auto newStem = stem;
+		newStem.replace_extension(".so");
+		modulePath /= newStem;
+
 		return Optional<Path> (std::move (modulePath));
 	}
 
@@ -322,12 +324,13 @@ Module::SnapshotList Module::getSnapshots (const std::string& modulePath)
 	for (auto& png : pngList)
 	{
 		filesystem::path p (png);
-		auto filename = p.filename ().generic_string ();
-		auto uid = Snapshot::decodeUID (filename);
+		auto filename = p.filename ().string ();
+		auto uid = Snapshot::decodeUID(filename.string());
 		if (!uid)
 			continue;
 		auto scaleFactor = 1.;
-		if (auto decodedScaleFactor = Snapshot::decodeScaleFactor (filename))
+		auto decodedFilename = filename.string();
+		if (auto decodedScaleFactor = Snapshot::decodeScaleFactor(decodedFilename))
 			scaleFactor = *decodedScaleFactor;
 
 		Module::Snapshot::ImageDesc desc;


### PR DESCRIPTION
hello. I am interested in your project and have analyzed the source code. We apologize for arbitrarily building the source code and testing for vulnerabilities. I ran about 40 vulnerability scans and found 2 vulnerabilities in the header file and 1 vulnerability in the cpp file.

Among these, static analysis was performed using codeql to analyze the cpp file. As a result, the cwe-416 vulnerability appeared in the path "/public.sdk/source/vst/hosting/module_linux.cpp".

The results of cwe-416 found two loopholes. The first one was found in lines 167 to 168 of the existing source code. In the code, I am using a variable called stem to change the extension of the file to ".so" and then adding that stem to the modulePath. At this time, changes to stem are also reflected in modulePath. This means that the contents of the existing stem may be lost when creating a new path. This may lead to memory leaks or unsafe memory manipulation. To keep your code safe, you should perform appropriate validation before memory manipulation on stem or other important variables.

The second loophole is that the variable named filename is retrieved and used from a temporary object, and the problem occurs because this temporary object goes out of scope and is no longer valid in memory. In code 326, the Snapshot::decodeUID function uses filename, which can be problematic if filename is retrieved from a temporary object. You need to make sure that there is a reference to filename within this function. If the decodeScaleFactor function in code 330 also references filename, using that reference after the temporary object's lifetime has expired may cause problems. By modifying your code, you can safely access the data associated with filename even after the temporary object's lifetime has ended.

Although it is not a major vulnerability and does not provide the best source code, I hope this helps.