### PR TITLE
Fix auwrapper MIDI output bugs

### DIFF
--- a/source/vst/auwrapper/auwrapper.h
+++ b/source/vst/auwrapper/auwrapper.h
@@ -123,15 +123,15 @@ public:
 			// iterate through the vector and get each item
 			std::vector<MIDIMessageInfoStruct>::iterator myIterator;
 			MIDIPacketList* pktlist = PacketList ();
+			MIDIPacket* pkt = MIDIPacketListInit (pktlist);
 
 			for (myIterator = mMIDIMessageList.begin (); myIterator != mMIDIMessageList.end ();
 			     myIterator++)
 			{
 				MIDIMessageInfoStruct item = *myIterator;
 
-				MIDIPacket* pkt = MIDIPacketListInit (pktlist);
 				bool tooBig = false;
-				Byte data[3] = {item.status, item.data1, item.data2};
+				Byte data[4] = {item.status, item.data1, item.data2, 0};
 				if ((pkt = MIDIPacketListAdd (pktlist, sizeof (mBuffersAllocated), pkt,
 				                              item.startFrame, 4, const_cast<Byte*> (data))) ==
 				    NULL)


### PR DESCRIPTION
This fixes MIDI output when there are multiple messages to send from a process call.

The main bug was `MIDIPacketListInit` being called for each added item, which resulted in only the last item being sent.

Also spotted `MIDIPacketListAdd` being passed a 3-byte buffer but with a reported byte count of 4; this could lead to uninitialised memory being added into pktlist.