### PR TITLE
fix AUWrapper::restartComponent kLatencyChanged handling

### DIFF
--- a/source/vst/auwrapper/auwrapper.mm
+++ b/source/vst/auwrapper/auwrapper.mm
@@ -2480,13 +2480,7 @@ tresult PLUGIN_API AUWrapper::restartComponent (int32 flags)
 
 	if (flags & kLatencyChanged)
 	{
-		AudioUnitEvent auEvent;
-		auEvent.mArgument.mProperty.mAudioUnit = GetComponentInstance ();
-		auEvent.mArgument.mProperty.mPropertyID = kAudioUnitProperty_Latency;
-		auEvent.mArgument.mProperty.mScope = kAudioUnitScope_Global;
-		auEvent.mArgument.mProperty.mElement = 0;
-		auEvent.mEventType = kAudioUnitEvent_PropertyChange;
-		AUEventListenerNotify (paramListenerRef, NULL, &auEvent);
+		PropertyChanged (kAudioUnitProperty_Latency, kAudioUnitScope_Global, 0);
 		result = kResultTrue;
 	}
 	// TODO: finish restartComponent implementation


### PR DESCRIPTION
The header documentation for AUEventListenerNotify states that this function
> can not be used for notifying changes to property values as these are
> internal to an audio unit and should not be issued outside of the audio unit itself

This is backed up by manual testing; Logic Pro does not re-query the latency after AUEventListenerNotify, but it does after PropertyChanged (i.e. with this fix applied)