### PR TITLE
Update VST3 system paths: add /usr/lib64/vst3

### DIFF
--- a/source/vst/hosting/module_linux.cpp
+++ b/source/vst/hosting/module_linux.cpp
@@ -264,12 +264,12 @@ Module::PathList Module::getModulePaths ()
 {
 	/* VST3 component locations on linux :
 	 * User privately installed	: $HOME/.vst3/
-	 * Distribution installed	: /usr/lib/vst3/
+	 * Distribution installed	: /usr/lib64/vst3/, /usr/lib/vst3/
 	 * Locally installed		: /usr/local/lib/vst3/
 	 * Application				: /$APPFOLDER/vst3/
 	 */
 
-	const auto systemPaths = {"/usr/lib/vst3/", "/usr/local/lib/vst3/"};
+	const auto systemPaths = {"/usr/lib64/vst3/", "/usr/lib/vst3/", "/usr/local/lib/vst3/"};
 
 	PathList list;
 	if (auto homeDir = getenv ("HOME"))


### PR DESCRIPTION
- For:
  - Fedora Linux
    - There is no /usr/lib/vst3 on Fedora anymore; it's all /usr/lib64/vst3 from here